### PR TITLE
build(make): :construction_worker: Added compilation hooks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "vendor/Criterion"]
 	path = vendor/Criterion
 	url = https://github.com/Snaipe/Criterion.git
+[submodule "vendor/minilibx-linux"]
+	path = vendor/minilibx-linux
+	url = https://github.com/42Paris/minilibx-linux.git

--- a/Makefile
+++ b/Makefile
@@ -39,12 +39,44 @@ run: all
 	@make --silent --file=./build/build_final.mf run
 	@echo "$(DIM)$(WHITE)*----------*$(RESET)"
 
+# ==================================[ HOOKS ]================================= #
+
+dev_hook_pre:
+ifneq ($(DEV_HOOK_PRE),)
+	@echo "🪝  $(WHITE)$(DIM)Developemnt pre-compilation hook$(RESET)"
+	@$(DEV_HOOK_PRE)
+	@echo "$(DIM)$(WHITE)*----------*$(RESET)"
+endif
+
+dev_hook_post:
+ifneq ($(DEV_HOOK_POST),)
+	@echo "🪝  $(WHITE)$(DIM)Developemnt post-compilation hook$(RESET)"
+	@$(DEV_HOOK_POST)
+	@echo "$(DIM)$(WHITE)*----------*$(RESET)"
+endif
+
+prod_hook_pre:
+ifneq ($(PROD_HOOK_PRE),)
+	@echo "🪝  $(WHITE)$(DIM)Production pre-compilation hook$(RESET)"
+	@$(PROD_HOOK_PRE)
+	@echo "$(DIM)$(WHITE)*----------*$(RESET)"
+endif
+
+prod_hook_post:
+ifneq ($(PROD_HOOK_POST),)
+	@echo "🪝  $(WHITE)$(DIM)Production post-compilation hook$(RESET)"
+	@$(PROD_HOOK_POST)
+	@echo "$(DIM)$(WHITE)*----------*$(RESET)"
+endif
+
 # ==================================[ DEBUG ]================================= #
 
 debug:
+	@make --silent dev_hook_pre
 	@echo "$(BLUE_BG)$(WHITE)$(BOLD)[ Building ]$(RESET)$(WHITE)$(ITALIC) debug"
 	@$(DOCKER) make -j$(CORES) --silent --file=./build/build_debug.mf
 	@echo "$(DIM)$(WHITE)*----------*$(RESET)"
+	@make --silent dev_hook_post
 
 debug_clean:
 	@echo "$(RED_BG)$(WHITE)$(BOLD)[ Cleaning ]$(RESET)$(WHITE)$(ITALIC) debug"
@@ -82,9 +114,11 @@ test_re: test_fclean
 # ==================================[ FINAL ]================================= #
 
 final: test
+	@make --silent prod_hook_pre
 	@echo "$(BLUE_BG)$(WHITE)$(BOLD)[ Building ]$(RESET)$(WHITE)$(ITALIC) final"
 	@make -j$(CORES) --silent --file=./build/build_final.mf
 	@echo "$(DIM)$(WHITE)*----------*$(RESET)"
+	@make --silent prod_hook_post
 
 final_clean:
 	@echo "$(RED_BG)$(WHITE)$(BOLD)[ Cleaning ]$(RESET)$(WHITE)$(ITALIC) final"

--- a/build/build_final.mf
+++ b/build/build_final.mf
@@ -21,7 +21,7 @@ all: $(BIN)
 
 $(BIN): $(FILES_OBJS) $(FILES_DEPS)
 # 	displays build command
-	@printf "$(BOLD)$(BLUE)building $(WHITE)%-30s$(RESET) $(CYAN)$(C_COMPILER) $(C_FLAGS) $(FILES_OBJS) -o $(BIN) $(LIBS)$(RESET)\n" "$@"
+	@printf "$(BOLD)$(BLUE)building $(WHITE)%-30s$(RESET) $(CYAN)$(C_COMPILER) $(C_FLAGS) $(FILES_OBJS) -o $(BIN) $(LIBS_PROD)$(RESET)\n" "$@"
 # 	builds binary
 	@mkdir -p $(@D)
 	@$(C_COMPILER) $(C_FLAGS) -o $(BIN) $(FILES_OBJS)

--- a/build/build_test.mf
+++ b/build/build_test.mf
@@ -15,7 +15,7 @@ FILES_SRCS = $(shell find ./ -wholename "$(DIR_TEST)/*.c")
 FILES_TEST = $(patsubst $(DIR_TEST)/%.c,$(DIR_BIN)/test/%,$(FILES_SRCS))
 FILES_DEPS = $(patsubst $(DIR_TEST)/%.c,$(DIR_DEPS)/%.d,$(FILES_SRCS))
 
-LIBS       += -lcriterion -L$(DIR_BIN) -l$(PROJECT)
+LIBS_DEV   += -lcriterion -L$(DIR_BIN) -l$(PROJECT)
 
 C_COMPILER = clang
 C_FLAGS    += -Werror -g $(DEBUG) $(SILENCED)
@@ -31,7 +31,7 @@ $(DIR_BIN)/test/%: $(DIR_TEST)/%.c $$(subst test_,,src/$$*.c)
 	@printf "$(GREEN)building $(WHITE)%-30s$(RESET) $(CYAN)$(C_COMPILER) $(C_FLAGS)\n$(RESET)" "$(notdir $@)"
 # 	builds object file
 	@mkdir -p $(@D)
-	@$(C_COMPILER) $(C_FLAGS) $(LIBS) $< -o $@
+	@$(C_COMPILER) $(C_FLAGS) $(LIBS_DEV) $< -o $@
 	@export LD_LIBRARY_PATH=$(pwd)$(DIR_BIN):$(LD_LIBRARY_PATH); \
 	$(VALGRIND) $@
 

--- a/build/setup.mf
+++ b/build/setup.mf
@@ -1,3 +1,7 @@
+# ===============================[ DEPENDENCIES ]============================= #
+
+-include ./build/color.mf
+
 # ==================================[ SETUP ]================================= #
 
 VALGRIND   = valgrind --trace-children=yes --leak-check=full --show-leak-kinds=all
@@ -12,7 +16,17 @@ DIR_BIN    = ./bin
 
 OPT        = -O2
 DEBUG      = -g
-LIBS       =
+LIBS_DEV   = 
+LIBS_PROD  = -lmlx -Lvendor/minilibx-linux
+
+DEV_HOOK_PRE   =
+DEV_HOOK_POST  =
+PROD_HOOK_PRE  = \
+	echo "$(BLUE_BG)$(WHITE)$(BOLD)[ Building ]$(RESET)$(WHITE)$(ITALIC) MLX"; \
+	if [ ! -f "vendor/minilibx-linux/libmlx.a" ]; then \
+		make --silent -C vendor/minilibx-linux all; \
+	fi
+PROD_HOOK_POST =
 
 C_COMPILER = clang
 I_FLAGS    = $(foreach dir,$(DIR_INCL),-I$(dir) )


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

- Build-related changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Cub3D does not include, build or use the [MinilibX](https://github.com/42Paris/minilibx-linux).

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

MinilibX has been added to *submodules* and is automatically compiled using new *compilation hooks*.

## Does this introduce a breaking change?

<!-- Yes or No -->
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

No.
